### PR TITLE
Add CNAME to preserve coghilldev.com on deploy

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+coghilldev.com


### PR DESCRIPTION
Follow-up to #8.

`npm run deploy` (`gh-pages -d dist`) overwrites the entire `gh-pages` branch. Without a `CNAME` file in the published output, GitHub Pages drops the `coghilldev.com` custom domain and the site 404s (it falls back to the `coghillb.github.io/portfolio/` project path, which breaks asset URLs because `vite base` is `/`).

Baking `public/CNAME` into the build so it ships in `dist` on every deploy keeps the custom domain attached permanently.

This commit landed on the feature branch just after #8 was merged, so it needs its own PR to reach `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)