### PR TITLE
Fix blurry About photo + clearer EmailJS errors

### DIFF
--- a/src/components/sections/Contact.jsx
+++ b/src/components/sections/Contact.jsx
@@ -83,7 +83,9 @@ export const Contact = () => {
         setForm(initial)
       })
       .catch((err) => {
-        console.error('EmailJS send error:', err)
+        // EmailJS rejects with { status, text }; log both so failures like a
+        // 412 "reconnect your Gmail account" read clearly instead of a minified blob.
+        console.error('EmailJS send failed:', err?.status, err?.text || err)
         setStatus('error')
       })
   }


### PR DESCRIPTION
Two small follow-ups after the redesign went live:

- **About-me photo**: was a 3072x4080 / 5.5MB Pixel photo rendered at 160px, so it loaded as a slow progressive JPEG (blurry until fully downloaded). Replaced with an 800x800 center-cropped, mozjpeg-compressed version (~100KB). Loads instantly, renders sharp. No code change (same `/aboutme.jpg`).
- **EmailJS errors**: log `err.status` / `err.text` on send failure so issues (like the current 412 "reconnect your Gmail account") read clearly in the console instead of a minified blob.

Note: the live contact form's 412 is a separate EmailJS-dashboard fix (reconnect the Gmail service); this PR just improves the error logging.