### PR TITLE
Fix View Site links blocked by glow-border overlay

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -211,6 +211,9 @@ body {
     inset: 0;
     border-radius: inherit;
     padding: 1px;
+    /* Decorative overlay only — must not swallow clicks on the card's
+       links (e.g. the "View Site" anchors on the web-design cards). */
+    pointer-events: none;
     background: linear-gradient(
       135deg,
       rgba(198, 255, 0, 0.6),


### PR DESCRIPTION
The .glow-border::before decorative pseudo-element covers the whole
card (position: absolute; inset: 0) but had no pointer-events rule, so
it intercepted clicks meant for the card's content — including the
"View Site" anchors on the web-design project cards. Add
pointer-events: none so clicks pass through to the links beneath.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ba9bUbzgHspK7ZAyk9CNs8